### PR TITLE
Se film tests er oprettet og ny exceptionhandler klasse er implementeret

### DIFF
--- a/src/main/java/com/example/kinoback/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/kinoback/exception/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.example.kinoback.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    // Exception handler method to catch RuntimeExceptions globally
+    @ExceptionHandler(RuntimeException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ResponseEntity<String> handleRuntimeException(RuntimeException e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Error: " + e.getMessage());
+    }
+}

--- a/src/main/java/com/example/kinoback/movie/MovieController.java
+++ b/src/main/java/com/example/kinoback/movie/MovieController.java
@@ -1,9 +1,8 @@
 package com.example.kinoback.movie;
 
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -23,3 +22,4 @@ public class MovieController {
     }
 
 }
+

--- a/src/test/java/com/example/kinoback/controller/MovieControllerUnitTest.java
+++ b/src/test/java/com/example/kinoback/controller/MovieControllerUnitTest.java
@@ -1,0 +1,63 @@
+package com.example.kinoback.controller;
+
+import com.example.kinoback.movie.Movie;
+import com.example.kinoback.movie.MovieController;
+import com.example.kinoback.movie.MovieService;
+import com.example.kinoback.showing.Showing;
+import com.example.kinoback.showing.ShowingController;
+import com.example.kinoback.showing.ShowingService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import java.util.Arrays;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+// Marking test as a Spring Web Mvc test
+@WebMvcTest(MovieController.class)
+public class MovieControllerUnitTest {
+
+    // Injects MockMvc instance used to simulate HTTP requests and test controller
+    @Autowired
+    private MockMvc mockMvc;
+
+    // Creates mock bean for service class to simulate its behavior
+    @MockBean
+    private MovieService movieService;
+
+    // Tests successful retrieval of showings
+    @Test
+    public void testGetMovies_Success() throws Exception {
+
+        // Arrange: Set up mock behavior to return list of three movies
+        when(movieService.getMovies()).thenReturn(Arrays.asList(new Movie(), new Movie(), new Movie()));
+
+        // Act: Perform GET request to the /movie/all endpoint
+        mockMvc.perform(MockMvcRequestBuilders.get("/movie/all"))
+
+                // Assert: Verify that the response status is 200 OK
+                .andExpect(status().isOk())
+                // Assert: Verify that the JSON response contains two elements
+                .andExpect(jsonPath("$.size()").value(3));
+    }
+
+    // Tests handling a failure scenario when service layer throws exception
+    @Test
+    public void testGetMovies_Failure() throws Exception {
+
+        // Arrange: Set up mock service to throw a RuntimeException
+        when(movieService.getMovies()).thenThrow(new RuntimeException("Service failure"));
+
+        // Act: Perform GET request to the /movie/all endpoint
+        mockMvc.perform(MockMvcRequestBuilders.get("/movie/all"))
+
+                // Assert: Verify that the response status is 500 Internal Server Error
+                .andExpect(status().isInternalServerError());
+    }
+
+}


### PR DESCRIPTION
Jeg har oprettet unit tests for getMovies():
1. Tester visning af filmliste med 3 film
2. Tester fejlet visning og exception handling ved runtime

Jeg har også oprettet en ny package exception, som nu indeholder en GlobalExceptionHandler klasse, som på nuværende tidspunkt håndterer runtime exceptions for alle controller klasserne. 
Der kan tilføjes flere typer exceptions i klassen, som derefter bliver håndteret af Spring. 

Sidstnævnte er en opgradering af den exception handler metode, jeg oprettede tidligere i ShowingController klassen, som derfor skal slettes.